### PR TITLE
prevent race condition on BackendNF list

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -30,17 +30,21 @@ type backendNF struct {
 
 var (
 	backends []*backendNF
+	nfNum    int
 	next     int
 	mutex    sync.Mutex
 )
 
 // returns the backendNF using RoundRobin algorithm
 func RoundRobin() (nf *backendNF) {
-	if len(backends) <= 0 {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if nfNum <= 0 {
 		logger.DispatchLog.Errorln("There are no backend NFs running")
 		return nil
 	}
-	if next >= len(backends) {
+	if next >= nfNum {
 		next = 0
 	}
 
@@ -80,7 +84,10 @@ func dispatchAddServer(serviceName string) {
 				logger.DiscoveryLog.Infoln("New Server found IPv4: ", ipv4.String())
 				backend := &backendNF{}
 				backend.address = ipv4.String()
+				mutex.Lock()
 				backends = append(backends, backend)
+				nfNum++
+				mutex.Unlock()
 				go backend.connectToServer()
 			}
 		}
@@ -114,6 +121,7 @@ func (b *backendNF) deleteBackendNF() {
 		if b1 == b {
 			backends[i] = backends[len(backends)-1]
 			backends = backends[:len(backends)-1]
+			nfNum--
 			break
 		}
 	}

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -121,7 +121,9 @@ func (b *backendNF) deleteBackendNF() {
 		if b1 == b {
 			backends[i] = backends[len(backends)-1]
 			backends = backends[:len(backends)-1]
+			mutex.Lock()
 			nfNum--
+			mutex.Unlock()
 			break
 		}
 	}


### PR DESCRIPTION
The current implementation has no protection on `RoundRobin()` and append operation of `backends`.

Although sctplb will replace the instance of the deleted element in `backends` for preventing sctplb forward msg to the shut-down NF:
```
backends[i] = backends[len(backends)-1]
backends = backends[:len(backends)-1]
```

But I think it should has a problem when multi AMFs shutdown simultaneously, for example:
```
backends: [ "AMF0", "AMF1", "AMF2" ]
next in RR: 2 (Will forward to AMF2)
```
If only have AMF2 leaves, it has no problem:
```
backends: [ "AMF0", "AMF1", "AMF1" ]
next in RR: 2 (Will forward to AMF1)
```
But When 2 AMFs leave:
```
backends: [ "AMF0", "AMF0", "AMF1" ]
next in RR: 2 (Will forward to AMF1, but AMF1 left already)
```
