### PR TITLE
Bumps go version to 1.21 (latest stable)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.17.5 AS lb 
+FROM golang:1.21.3-bookworm AS lb
 
 LABEL maintainer="ONF <omec-dev@opennetworking.org>"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/omec-project/sctplb
 
-go 1.17
+go 1.21
 
 replace github.com/omec-project/sctplb => ./
 


### PR DESCRIPTION
This PR bumps the go version to 1.21 which is the latest stable release. 

The update is accomplished by running following commands:
```
go mod edit -go=1.21
go mod tidy
```

Reference: https://tip.golang.org/doc/go1.21